### PR TITLE
返回更详细的搜索结果数据

### DIFF
--- a/src/lib/components/amap-search-box.vue
+++ b/src/lib/components/amap-search-box.vue
@@ -136,7 +136,7 @@ export default {
         let {poiList: {pois}} = result;
 
         let LngLats = pois.map(poi => ({lat: poi.location.lat, lng: poi.location.lng}));
-        this._onSearchResult(LngLats);
+        this._onSearchResult(LngLats, pois);
       });
     },
     changeTip(tip) {


### PR DESCRIPTION
如果只返回经纬度, 地图上只能标记 marker 的位置, 而不能显示更多的信息(如: name), 这通常不太方便.