### PR TITLE
Fixed Amap info-window open/close bug

### DIFF
--- a/src/homepage/demos/info-window.vue
+++ b/src/homepage/demos/info-window.vue
@@ -2,8 +2,10 @@
 <template>
   <div id="demoComponent" class="demo-component">
       <el-amap vid="amap" :zoom="zoom" :center="center">
-        <el-amap-info-window v-for="(window, index) in windows" :key="index" :position="window.position" :content="window.content" :open="window.open" :events="window.events"></el-amap-info-window>
+        <el-amap-info-window v-for="window in windows" :visible="show" :position="window.position" :content="window.content" :open="window.open" :events="window.events"></el-amap-info-window>
       </el-amap>
+    
+      <button @click="toggle">Toggle Window</button>
   </div>
 </template>
 
@@ -14,6 +16,7 @@ export default {
     return {
       zoom: 14,
       center: [121.5273285, 31.21515044],
+      show: true,
       windows: [
         {
           position: [121.5273285, 31.21515044],
@@ -26,6 +29,11 @@ export default {
         }
       ]
     };
+  },
+  methods: {
+    toggle() {
+      this.show = !this.show;
+    }
   }
 };
 </script>

--- a/src/lib/components/amap-info-window.vue
+++ b/src/lib/components/amap-info-window.vue
@@ -26,7 +26,8 @@ export default {
       },
       handlers: {
         visible(flag) {
-          flag === false ? this.close() : this.open();
+          // fixed Amap info-window reopen 
+          flag === false ? this.close() : this.open(this.G.map, [this.si.position.lng, this.si.position.lat]);
         }
       }
     };


### PR DESCRIPTION
Amap info-window component has `close` and `open` methods to control the visibility of itself. But `open` method needs two params `map` and `position` : http://lbs.amap.com/fn/jsdemo_loader/?url=http%3A%2F%2Fwebapi.amap.com%2Fdemos%2FinfoWindowAndContextmenu%2FAdvancedInfoWindow.html

