### PR TITLE
update: marker doc and example

### DIFF
--- a/src/homepage/demos/marker.vue
+++ b/src/homepage/demos/marker.vue
@@ -25,7 +25,8 @@ export default {
               alert('click marker');
             },
             dragend: (e) => {
-              this.markers[0].position = [e.lnglat.lng, e.lnglat.lat];
+              const {lng, lat} = e.target.getPosition();
+              this.markers[0].position = [lng, lat];
             }
           },
           visible: true,

--- a/src/homepage/docs/marker.md
+++ b/src/homepage/docs/marker.md
@@ -32,7 +32,8 @@ export default {
               alert('click marker');
             },
             dragend: (e) => {
-              this.markers[0].position = [e.lnglat.lng, e.lnglat.lat];
+              const {lng, lat} = e.target.getPosition();
+              this.markers[0].position = [lng, lat];
             }
           },
           visible: true,


### PR DESCRIPTION
### 做了什么
Marker的`dragend`事件参数为`MapEvent`，它的`lnglat`为鼠标光标位置的经纬度，而不是Marker定位点的经纬度。

修正前：
拖动、松开Marker时，Marker会跳到光标位置

修正后：
拖动、松开Marker时，Marker不跳动
