### PR TITLE
fix doc error: 快速上手文档示例地图元素高度为0

### DIFF
--- a/src/docs/zh-cn/introduction/quick-start.md
+++ b/src/docs/zh-cn/introduction/quick-start.md
@@ -171,7 +171,7 @@ export default {
 </script>
 
 <style>
-.amap-box {
+.amap-wrapper {
   width: 500px;
   height: 500px;
 }


### PR DESCRIPTION
[amap.vue里的样式](https://github.com/ElemeFE/vue-amap/blob/dev/src/lib/components/amap.vue#L234)覆盖了文档中设置到高度

高度设置到外部选择器。