### PR TITLE
update: support more AMapUI version

### DIFF
--- a/src/lib/services/lazy-amap-api-loader.js
+++ b/src/lib/services/lazy-amap-api-loader.js
@@ -62,7 +62,14 @@ export default class AMapAPILoader {
     if (!this._config.uiVersion || window.AMapUI) return Promise.resolve();
     return new Promise((resolve, reject) => {
       const UIScript = document.createElement('script');
-      UIScript.src = `${this._config.protocol}://webapi.amap.com/ui/${this._config.uiVersion}/main-async.js`;
+      const [versionMain, versionSub, versionDetail] = this._config.uiVersion.split('.');
+      if (versionMain === undefined || versionSub === undefined) {
+        console.error('amap ui version is not correct, please check! version: ', this._config.uiVersion);
+        return;
+      }
+      let src = `${this._config.protocol}://webapi.amap.com/ui/${versionMain}.${versionSub}/main-async.js`;
+      if (versionDetail) src += `?v=${versionMain}.${versionSub}.${versionDetail}`;
+      UIScript.src = src;
       UIScript.type = 'text/javascript';
       UIScript.async = true;
       this._document.head.appendChild(UIScript);


### PR DESCRIPTION
文档：
VueAMap.initAMapApiLoader({
  key: 'YOUR_KEY',
  plugin: ['AMap.Scale', 'AMap.OverView', 'AMap.ToolBar', 'AMap.MapType',...],
  uiVersion: '1.0.11' // 版本号
});

依照文档会报错，官方文档的引入是： 
<script src="//webapi.amap.com/ui/1.0/main-async.js?v=1.0.11" />

现在支持： '1.0' 或者 ’1.0.11‘