### PR TITLE
fix: custom render component is never been destroyed

### DIFF
--- a/src/lib/components/amap-info-window.vue
+++ b/src/lib/components/amap-info-window.vue
@@ -32,15 +32,20 @@ export default {
       },
       converters: {
         template(tpl) {
-          return compile(tpl, self);
+          const template = compile(tpl, self);
+          this.$customContent = template;
+          return template.$el;
         },
         vnode(vnode) {
           const _vNode = typeof vnode === 'function' ? vnode(self) : vnode;
           const vNode = mountedVNode(_vNode);
-          return vNode;
+          this.$customContent = vNode;
+          return vNode.$el;
         },
         contentRender(renderFn) {
-          return mountedRenderFn(renderFn, self);
+          const template = mountedRenderFn(renderFn, self);
+          this.$customContent = template;
+          return template.$el;
         }
       },
       handlers: {
@@ -59,6 +64,10 @@ export default {
   },
   destroyed() {
     this.$amapComponent.close();
+
+    if (this.$customContent && this.$customContent.$destroy) {
+      this.$customContent.$destroy();
+    }
   },
   methods: {
     __initComponent(options) {

--- a/src/lib/components/amap-marker.vue
+++ b/src/lib/components/amap-marker.vue
@@ -63,16 +63,20 @@ export default {
           return new AMap.Icon(options);
         },
         template(tpl) {
-          return compile(tpl, self);
+          const template = compile(tpl, self);
+          this.$customContent = template;
+          return template.$el;
         },
         vnode(vnode) {
           const _vNode = typeof vnode === 'function' ? vnode(self) : vnode;
           const vNode = mountedVNode(_vNode);
-          return vNode;
+          this.$customContent = vNode;
+          return vNode.$el;
         },
         contentRender(renderFn) {
           const template = mountedRenderFn(renderFn, self);
-          return template;
+          this.$customContent = template;
+          return template.$el;
         },
         label(options) {
           const { content = '', offset = [0, 0] } = options;
@@ -120,6 +124,11 @@ export default {
       return h('div', slots);
     }
     return null;
+  },
+  destroyed() {
+    if (this.$customContent && this.$customContent.$destroy) {
+      this.$customContent.$destroy();
+    }
   }
 };
 </script>

--- a/src/lib/mixins/register-component.js
+++ b/src/lib/mixins/register-component.js
@@ -80,7 +80,7 @@ export default {
       if (type && converter) {
         return converter(sourceData);
       } else if (this.converters && this.converters[key]) {
-        return this.converters[key](sourceData);
+        return this.converters[key].call(this, sourceData);
       } else {
         const convertFn = commonConvertMap[key];
         if (convertFn) return convertFn(sourceData);

--- a/src/lib/utils/compile.js
+++ b/src/lib/utils/compile.js
@@ -18,15 +18,18 @@ export const compile = (tpl, vm) => {
     ...node
   });
 
-  return vNode.$mount().$el;
+  vNode.$mount();
+  return vNode;
 };
 
 export const mountedVNode = (vn) => {
   const instance = new Vue({render: (h) => h('div', vn)});
-  return instance.$mount().$el;
+  instance.$mount();
+  return instance;
 };
 
 export const mountedRenderFn = (renderFn, vueInstance) => {
   const instance = new Vue({render: h => renderFn(h, vueInstance)});
-  return instance.$mount().$el;
+  instance.$mount();
+  return instance;
 };


### PR DESCRIPTION
When using `template` or `content-render` props in `amap-marker` and `amap-info-window`, the customized component will never be destroyed, which is prone to memory leak or incompleteness in lifecycle.