### PR TITLE
在搜索组件的提示中 显示提示的district字段

### DIFF
--- a/src/lib/components/amap-search-box.vue
+++ b/src/lib/components/amap-search-box.vue
@@ -15,7 +15,10 @@
           :key="index"
           @click="changeTip(tip)"
           @mouseover="selectedTip=index"
-          :class="{'autocomplete-selected': index === selectedTip}">{{tip.name}}</li>
+          :class="{'autocomplete-selected': index === selectedTip}">
+            {{tip.name}}
+            <span>{{tip.district}}</span>
+          </li>
       </ul>
     </div>
   </div>
@@ -79,9 +82,15 @@
           box-shadow: 0 1px 1px rgba(0,0,0,.1);
           padding: 0 10px;
           cursor: pointer;
+          white-space: nowrap;
 
           &.autocomplete-selected {
             background: #eee;
+          }
+
+          span{
+            font-size:.8em;
+            color:#c1c1c1;
           }
         }
       }


### PR DESCRIPTION
原搜索组件, 在全国范围内搜索"汉堡王(北大街店)", 会出现两条"汉堡王(北大街店)", 无法区分是哪个地区的
修改后, 在原来的提示后面再加上district字段, 搜索"汉堡王(北大街店)"显示为: ["汉堡王(北大街店) _陕西省西安市新城区_", "汉堡王(北大街店) _黑龙江省齐齐哈尔市克山镇_"]