### PR TITLE
amap组件增加touchZoomCenter属性

### DIFF
--- a/src/lib/components/amap.vue
+++ b/src/lib/components/amap.vue
@@ -47,6 +47,7 @@ export default {
     'jogEnable',
     'scrollWheel',
     'touchZoom',
+    'touchZoomCenter',
     'mapStyle',
     'plugin',
     'features',


### PR DESCRIPTION
移动端地图缩放以地图中心点缩放，参见：[touchZoomCenter](https://lbs.amap.com/api/javascript-api/reference/map)