### PR TITLE
fix: 增加世界地图开启参数

### DIFF
--- a/src/lib/components/amap.vue
+++ b/src/lib/components/amap.vue
@@ -21,7 +21,7 @@ export default {
     'pitch',
     'buildingAnimation',
     'pitchEnable',
-
+    'showOversea',  // 开启世界地图
     'vid',
     'events',
     'center',

--- a/src/lib/components/amap.vue
+++ b/src/lib/components/amap.vue
@@ -22,6 +22,7 @@ export default {
     'buildingAnimation',
     'pitchEnable',
     'showOversea',  // 开启世界地图
+    'languageCode', // 多语言配置
     'vid',
     'events',
     'center',


### PR DESCRIPTION
官方链接：https://lbs.amap.com/api/javascript-api-v2/guide/map/world-map
<img width="1902" height="704" alt="image" src="https://github.com/user-attachments/assets/e92e16d0-5cb0-45da-bb28-89752c30c126" />

新增showOversea参数，使用el-amap时，传递showOversea使用即可开启
```
<el-amap
      ref="map"
      :vid="'amap-demo'"
      :zoom="12"
      :events="mapEvents"
      :showOversea="true"
      :center="center">
    </el-amap>
```